### PR TITLE
Add pagination to the /inventory/all API endpoint

### DIFF
--- a/controllers/inventoryController.js
+++ b/controllers/inventoryController.js
@@ -92,11 +92,26 @@ function getBasicItem(item) {
 	return formatItem;
 }
 
-
-
 exports.getItems = function (req, res, next) {
+	let pageSize = Number(req.query.pagesize);
+	let page = Number(req.query.page);
 
-	Item.find().exec().then((items) => {
+	if ((pageSize || page) && !(pageSize && page)) {  // The pagination parameters are invalid
+		return next(new CodedError('If using pagination, both "pagesize" and "page" must be valid', 400));
+	}
+
+	// Default values (to avoid working on undefined ones)
+	pageSize = pageSize || 0;  // 0 = unlimited
+	page = page || 1;  // The first page is #1
+
+	let skip = pageSize * (page - 1);
+
+	Item.find()
+	.limit(pageSize)
+	.skip(skip)
+	.sort('name')
+	.exec()
+	.then((items) => {
 		return res.status(200).send(items);
 	}).catch((reason) => {
 		return next(reason);


### PR DESCRIPTION
Now the `/inventory/all` endpoint can be queried with the following
optional parameters as querystrings:

 - `pagesize`: Amount of items to be shown per page
 - `page`: The number of the page to be shown (starts at 1)

The endpoint can be queried up to an unlimited page number, but the
response will be an empty array if no items are left to be shown.

Despite both parameters being optional, either both or none of them
should be used. Querying the endpoint with only one of them will produce
an HTTP 400 error.